### PR TITLE
Add manual measures availability in fmt_scan_minimal

### DIFF
--- a/bin/romi_scanner_rest_api
+++ b/bin/romi_scanner_rest_api
@@ -76,6 +76,7 @@ def fmt_scan_minimal(scan):
     has_point_cloud = files_metadata["point_cloud"] is not None
     has_skeleton = files_metadata["skeleton"] is not None
     has_angles = files_metadata["angles"] is not None
+    has_manual_measures = "measures" in metadata
 
     return {
         "id": scan.id,
@@ -94,7 +95,8 @@ def fmt_scan_minimal(scan):
         "hasMesh": has_mesh,
         "hasPointCloud": has_point_cloud,
         "hasSkeleton": has_skeleton,
-        "hasAngleData": has_angles
+        "hasAngleData": has_angles,
+        "hasManualMeasures": has_manual_measures
     }
 
 


### PR DESCRIPTION
I hope this respects the rest of the romidata code, this is a simple change to facilitate access to manual measures availability in the visualizer to avoid making multiple http requests.