### PR TITLE
Add hasAutomatedMeasures field to `fmt_scan_minimal`

### DIFF
--- a/bin/romi_scanner_rest_api
+++ b/bin/romi_scanner_rest_api
@@ -96,7 +96,8 @@ def fmt_scan_minimal(scan):
         "hasPointCloud": has_point_cloud,
         "hasSkeleton": has_skeleton,
         "hasAngleData": has_angles,
-        "hasManualMeasures": has_manual_measures
+        "hasManualMeasures": has_manual_measures,
+        "hasAutomatedMeasures": has_angles
     }
 
 


### PR DESCRIPTION
Turns out that having angles data is equivalent to having automated measures. Still added the `hasAutomatedMeasures` field for readability and practical purposes.

Close #30 